### PR TITLE
Staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@
 # When you deploy, set this as a secret env var in your hosting provider.
 # The endpoint has no built-in rate limiting, so pick a long, unguessable
 # password and enable your host's rate limiting / bot protection if available.
+# GOTCHA: Next.js runs dotenv-expand over .env files, so a literal $ in the
+# value must be escaped as \$ (quotes do NOT protect it) — otherwise $WORD is
+# swallowed as an empty variable reference. Hosting-provider dashboards take
+# the raw value with no escaping.
 ADMIN_PASSWORD=
 
 # Optional: mount the app under a subpath (e.g. /desktop) when serving it behind

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,14 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "babel-plugin-react-compiler": "1.0.0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -750,9 +753,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "win7-web-os",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -21,7 +24,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "win7-web-os",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -397,11 +397,10 @@
   --ie-titlebar-icon-size: var(--tb-popup-icon-size);
   --ie-address-height: 24px;
   --ie-address-bg: #fff;
-  /* Inset (sunken) border in the same grey as the refresh-button dividers. */
-  --ie-address-border: 2px inset var(--ie-action-divider-color);
-  /* Light-blue accent ring just outside the inset border — a second, outer
-     border drawn with box-shadow spread so it hugs the border radius. */
-  --ie-address-radius: 2px;
+  /* Flat 1px hairline, square corners — IE7's address field sits flush on the
+     glass rather than sunken (the 2px inset read as IE6/XP). */
+  --ie-address-border: 1px solid rgba(130, 146, 162, 0.9);
+  --ie-address-radius: 0;
   --ie-address-text: #333;
   --ie-address-icon-size: 16px;
   /* Refresh + clear buttons: square, sized to the address-bar height and
@@ -439,6 +438,26 @@
   --ie-content-bg: #fff;
   /* Placeholder project-thumbnail fill (replaced with real assets in Task 12). */
   --ie-project-thumb-bg: rgba(200, 210, 220, 0.5);
+  /* In-page content cards (Home tiles, Getting Started card).
+     Referenced by the IE page stylesheets. */
+  --ie-external-card-bg: rgba(245, 249, 253, 0.9);
+  --ie-external-card-border: 1px solid rgba(160, 180, 200, 0.55);
+  --ie-external-card-radius: 4px;
+  /* IE7 retro chrome — soft blue band shared by the tab strip and page-links
+     row, plus the tab and bottom status-bar treatments. */
+  --ie-chrome-band-bg: linear-gradient(#f4f8fc, #dee9f5);
+  --ie-chrome-band-border: 1px solid rgba(150, 168, 190, 0.7);
+  --ie-tab-height: 24px;
+  --ie-tab-bg: linear-gradient(#fefefe, #e9f1fa);
+  --ie-tab-border: 1px solid rgba(120, 142, 170, 0.85);
+  --ie-tab-title-color: #1a3a5c;
+  --ie-tab-font-size: 11px;
+  --ie-tab-star-color: #e8a33d;
+  --ie-status-height: 22px;
+  --ie-status-bg: linear-gradient(#f6f8fa, #dde6ef);
+  --ie-status-text: #3b4b5c;
+  --ie-status-font-size: 11px;
+  --ie-status-divider: 1px solid rgba(150, 168, 190, 0.6);
 }
 
 /* =====================================================================

--- a/src/app/win7/desktop/page.tsx
+++ b/src/app/win7/desktop/page.tsx
@@ -1,7 +1,15 @@
+import { cookies } from 'next/headers'
+
 import { DesktopScreen } from '@/components/screens/desktop/DesktopScreen'
+import { ADMIN_COOKIE_NAME, isAdminCookieValid } from '@/lib/adminAuth'
 
 // Gated deep link to the desktop (see src/proxy.ts). The primary flow renders
-// the desktop at /win7 itself without ever changing the URL.
-export default function DesktopPage() {
-  return <DesktopScreen />
+// the desktop at /win7 itself without ever changing the URL. The admin flag is
+// derived the same way as at /win7 so per-role icon hiding applies here too
+// (guest is the complement: !isAdmin).
+export default async function DesktopPage() {
+  const cookieStore = await cookies()
+  const isAdmin = await isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value)
+
+  return <DesktopScreen isAdmin={isAdmin} />
 }

--- a/src/app/win7/page.tsx
+++ b/src/app/win7/page.tsx
@@ -18,5 +18,5 @@ export default async function Win7Page() {
   const isAdmin = await isAdminCookieValid(cookieStore.get(ADMIN_COOKIE_NAME)?.value)
   const isGuest = cookieStore.get(GUEST_COOKIE_NAME)?.value === '1'
 
-  return isAdmin || isGuest ? <DesktopScreen /> : <LoginScreen />
+  return isAdmin || isGuest ? <DesktopScreen isAdmin={isAdmin} /> : <LoginScreen />
 }

--- a/src/components/screens/desktop/DesktopScreen.tsx
+++ b/src/components/screens/desktop/DesktopScreen.tsx
@@ -1,19 +1,46 @@
 'use client'
 
+import { useMemo } from 'react'
+
 import { Desktop } from '@/components/screens/desktop/Desktop'
 import { DESKTOP_ICONS } from '@/components/screens/desktop/desktopIcons'
+import { isWindowDisabled } from '@/components/screens/desktop/disabledWindows'
 import { IconGrid } from '@/components/screens/desktop/IconGrid'
 import { Taskbar } from '@/components/screens/desktop/Taskbar'
 import { WindowManager } from '@/components/screens/desktop/WindowManager'
+import { useDesktopPersistence } from '@/hooks/useDesktopPersistence'
+
+export interface DesktopScreenProps {
+  /** Server-derived admin flag — passed by the page so icons flagged
+   *  hideForAdmin are filtered before first render (no flash, and the hidden
+   *  icons never register grid cells). Guest is the complement: !isAdmin. */
+  isAdmin?: boolean
+}
 
 /**
- * The full desktop composition. Rendered by /win7 (when the server sees a
- * valid session cookie) and by the /win7/desktop deep link.
+ * The full desktop composition. Rendered at the app root when the server sees
+ * a valid session cookie (src/app/page.tsx).
  */
-export function DesktopScreen() {
+export function DesktopScreen({ isAdmin = false }: DesktopScreenProps) {
+  useDesktopPersistence()
+
+  // Windows turned off site-wide never register a grid cell, in any session;
+  // the role then drops its own hidden icons. Guest is the complement of admin
+  // (assume guest whenever !isAdmin), so it needs no separate flag. Memoized so
+  // the array identity is stable across re-renders — it is a dependency of
+  // IconGrid's registration effect.
+  const visibleIcons = useMemo(() => {
+    const availableIcons = DESKTOP_ICONS.filter(
+      (icon) => !isWindowDisabled(icon.windowKey, isAdmin)
+    )
+    return isAdmin
+      ? availableIcons.filter((icon) => !icon.hideForAdmin)
+      : availableIcons.filter((icon) => !icon.hideForGuest)
+  }, [isAdmin])
+
   return (
     <>
-      <Desktop iconGrid={<IconGrid icons={DESKTOP_ICONS} />} windowLayer={<WindowManager />} />
+      <Desktop iconGrid={<IconGrid icons={visibleIcons} />} windowLayer={<WindowManager />} />
       <Taskbar />
     </>
   )

--- a/src/components/screens/desktop/IconGrid/IconGrid.tsx
+++ b/src/components/screens/desktop/IconGrid/IconGrid.tsx
@@ -6,6 +6,8 @@
 import { DndContext, type DragEndEvent } from '@dnd-kit/core'
 import { useEffect, useState } from 'react'
 import { DesktopIcon } from '../DesktopIcon'
+import { openWindowIfEnabled } from '../openWindowIfEnabled'
+import type { WindowKey } from '../windowKeys'
 import styles from './IconGrid.module.css'
 import { useDesktopSensors } from '@/hooks/useDesktopSensors'
 import {
@@ -25,7 +27,7 @@ import {
   clearSelection,
   selectDesktopIcons,
 } from '@/store/slices/desktopSlice'
-import { openWindow, type WindowKind } from '@/store/slices/windowSlice'
+import type { WindowKind } from '@/store/slices/windowSlice'
 
 interface IconGridProps {
   icons: Array<{
@@ -34,6 +36,8 @@ interface IconGridProps {
     iconSrc: string
     windowKind: WindowKind
     windowTitle: string
+    windowKey: WindowKey
+    windowSize?: { width: number; height: number }
   }>
 }
 
@@ -117,9 +121,11 @@ export function IconGrid({ icons: _icons }: IconGridProps) {
             iconSrc={iconDef.iconSrc}
             onOpen={() =>
               dispatch(
-                openWindow({
+                openWindowIfEnabled({
                   kind: iconDef.windowKind,
                   title: iconDef.windowTitle,
+                  windowKey: iconDef.windowKey,
+                  size: iconDef.windowSize,
                 })
               )
             }

--- a/src/components/screens/desktop/InternetExplorer/IEAddressBar.tsx
+++ b/src/components/screens/desktop/InternetExplorer/IEAddressBar.tsx
@@ -4,7 +4,7 @@ import { useId, useRef, useState } from 'react'
 
 import { filterPages, IE_PAGES, inputToRoute, pageUrl, resolvePage } from './ieRoutes'
 import styles from './IEToolbar.module.css'
-import { assetPaths } from '@/lib/assetPaths'
+import { assetPaths, withBasePath } from '@/lib/assetPaths'
 
 interface IEAddressBarProps {
   /** Nickname of the current page (history-stack value). */
@@ -109,7 +109,7 @@ export function IEAddressBar({ currentUrl, onOpentab, onNavigate, onRefresh }: I
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         className={styles.favicon}
-        src={assetPaths.desktopIcons.internetExplorer}
+        src={withBasePath(assetPaths.desktopIcons.internetExplorer)}
         alt=""
         aria-hidden="true"
       />

--- a/src/components/screens/desktop/InternetExplorer/IEPageLinks.module.css
+++ b/src/components/screens/desktop/InternetExplorer/IEPageLinks.module.css
@@ -1,11 +1,13 @@
 /* Blue underlined page links pinned to the top-left of the IE content area,
-   replacing the former favorites bar. Sits on the white content background. */
+   replacing the former favorites bar. Sits on the IE7 chrome band so it reads
+   as the browser's Links bar rather than page content. */
 .pageLinks {
   display: flex;
   align-items: center;
   gap: var(--ie-pagelinks-gap);
   padding: var(--ie-pagelinks-padding);
-  background: var(--ie-content-bg);
+  background: var(--ie-chrome-band-bg);
+  border-bottom: var(--ie-chrome-band-border);
   flex-shrink: 0;
 }
 

--- a/src/components/screens/desktop/InternetExplorer/IEPageLinks.tsx
+++ b/src/components/screens/desktop/InternetExplorer/IEPageLinks.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import styles from './IEPageLinks.module.css'
-import { IE_PAGES } from './ieRoutes'
+import { IE_TOP_PAGES } from './ieRoutes'
 
 interface IEPageLinksProps {
   onNavigate: (nickname: string) => void
@@ -10,15 +10,16 @@ interface IEPageLinksProps {
 
 /**
  * Blue underlined page links pinned to the top-left of the window content,
- * replacing the former favorites bar. One link per registry entry. The targets
- * are in-app routes (not real URLs), so each link is a button styled to read as
+ * replacing the former favorites bar. One link per top-level registry entry
+ * (subpages are reachable from their parent page instead). The targets are
+ * in-app routes (not real URLs), so each link is a button styled to read as
  * a classic hyperlink. Redirect entries go through onOpentab (new browser tab
  * + in-app redirect page) instead of onNavigate.
  */
 export function IEPageLinks({ onNavigate, onOpentab }: IEPageLinksProps) {
   return (
     <nav className={styles.pageLinks} aria-label="Pages">
-      {IE_PAGES.map((page) => (
+      {IE_TOP_PAGES.map((page) => (
         <button
           key={page.nickname}
           className={styles.link}

--- a/src/components/screens/desktop/InternetExplorer/IEToolbar.module.css
+++ b/src/components/screens/desktop/InternetExplorer/IEToolbar.module.css
@@ -82,7 +82,7 @@
   align-items: center;
   justify-content: center;
   border: none;
-  border-left: 2px solid var(--ie-action-divider-color);
+  border-left: 1px solid var(--ie-action-divider-color);
   border-radius: 0;
   background: transparent;
   box-shadow: none;

--- a/src/components/screens/desktop/InternetExplorer/InternetExplorerWindow.module.css
+++ b/src/components/screens/desktop/InternetExplorer/InternetExplorerWindow.module.css
@@ -26,3 +26,90 @@
   object-fit: contain;
   display: block;
 }
+
+/* ── IE7 retro chrome ─────────────────────────────────────────────── */
+
+/* Single-tab strip under the address bar. */
+.tabStrip {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: var(--ie-tab-height);
+  padding: 2px 4px 0;
+  background: var(--ie-chrome-band-bg);
+  border-bottom: var(--ie-chrome-band-border);
+  flex-shrink: 0;
+}
+
+/* Favorites star pinned left of the tabs, like IE7's Favorites Center. */
+.favStar {
+  align-self: center;
+  font-size: 13px;
+  line-height: 1;
+  padding: 0 6px 0 2px;
+  color: var(--ie-tab-star-color);
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.8);
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: calc(100% - 2px);
+  min-width: 120px;
+  max-width: 220px;
+  padding: 0 10px;
+  background: var(--ie-tab-bg);
+  border: var(--ie-tab-border);
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+}
+
+.tabFavicon {
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
+}
+
+.tabTitle {
+  font-size: var(--ie-tab-font-size);
+  color: var(--ie-tab-title-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Short empty nub after the active tab — IE7's new-tab stub. */
+.tabStub {
+  width: 18px;
+  height: calc(100% - 6px);
+  background: var(--ie-tab-bg);
+  border: var(--ie-tab-border);
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+  opacity: 0.7;
+}
+
+/* Status bar along the window bottom: Done · security zone · zoom. */
+.statusBar {
+  display: flex;
+  align-items: center;
+  height: var(--ie-status-height);
+  padding: 0 8px;
+  background: var(--ie-status-bg);
+  border-top: var(--ie-status-divider);
+  font-size: var(--ie-status-font-size);
+  color: var(--ie-status-text);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.statusDone {
+  flex: 1;
+}
+
+.statusSegment {
+  padding: 0 10px;
+  border-left: var(--ie-status-divider);
+  white-space: nowrap;
+}

--- a/src/components/screens/desktop/InternetExplorer/InternetExplorerWindow.tsx
+++ b/src/components/screens/desktop/InternetExplorer/InternetExplorerWindow.tsx
@@ -7,7 +7,7 @@ import { IEToolbar } from './IEToolbar'
 import styles from './InternetExplorerWindow.module.css'
 import { GettingStartedPage, HomePage, RedirectPage } from './pages'
 import { useIENavigation } from './useIENavigation'
-import { assetPaths } from '@/lib/assetPaths'
+import { assetPaths, withBasePath } from '@/lib/assetPaths'
 
 export interface InternetExplorerWindowProps {
   /** Redux window id — wires the OS chrome (geometry, focus, controls). */
@@ -60,20 +60,44 @@ export function InternetExplorerWindow({ windowId, initialRoute }: InternetExplo
     // eslint-disable-next-line @next/next/no-img-element
     <img
       className={styles.titleBarIcon}
-      src={assetPaths.desktopIcons.internetExplorer}
+      src={withBasePath(assetPaths.desktopIcons.internetExplorer)}
       alt=""
       aria-hidden="true"
     />
   )
 
+  const currentPage = resolvePage(nav.currentUrl)
+
   return (
     <WindowWrapper windowId={windowId} icon={icon} toolbar={toolbar} bodySpace={false}>
       <div className={styles.ieBody}>
+        {/* IE7-style single-tab strip. Decorative chrome (hence aria-hidden):
+            the star and new-tab stub don't act; the tab mirrors the page the
+            window is already on. */}
+        <div className={styles.tabStrip} aria-hidden="true">
+          <span className={styles.favStar}>★</span>
+          <div className={styles.tab}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              className={styles.tabFavicon}
+              src={withBasePath(assetPaths.desktopIcons.internetExplorer)}
+              alt=""
+            />
+            <span className={styles.tabTitle}>{currentPage?.title ?? nav.currentUrl}</span>
+          </div>
+          <div className={styles.tabStub} />
+        </div>
         <IEPageLinks onNavigate={nav.navigate} onOpentab={handleOpentab} />
         {/* reloadKey changes on navigation and refresh, remounting the page so a
             refresh re-runs it without adding a history entry. */}
         <div key={nav.reloadKey} className={styles.content}>
           {renderContent()}
+        </div>
+        {/* IE7 status bar — Done · security zone · zoom, all static chrome. */}
+        <div className={styles.statusBar} aria-hidden="true">
+          <span className={styles.statusDone}>Done</span>
+          <span className={styles.statusSegment}>Internet | Protected Mode: Off</span>
+          <span className={styles.statusSegment}>100%</span>
         </div>
       </div>
     </WindowWrapper>

--- a/src/components/screens/desktop/InternetExplorer/ieRoutes.ts
+++ b/src/components/screens/desktop/InternetExplorer/ieRoutes.ts
@@ -43,6 +43,10 @@ export const IE_PAGES: IEPage[] = [
   },
 ]
 
+/** Top-level pages only — nested nicknames (subpages, e.g. `about:projects/…`)
+ *  stay out of the page-links row and the Home tiles. */
+export const IE_TOP_PAGES: IEPage[] = IE_PAGES.filter((page) => !page.nickname.includes('/'))
+
 /** The page IE opens on by default (its nickname). */
 export const DEFAULT_ROUTE = IE_PAGES[0].nickname
 

--- a/src/components/screens/desktop/InternetExplorer/pages/HomePage.tsx
+++ b/src/components/screens/desktop/InternetExplorer/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DEFAULT_ROUTE, IE_PAGES } from '../ieRoutes'
+import { DEFAULT_ROUTE, IE_TOP_PAGES } from '../ieRoutes'
 
 import styles from './HomePage.module.css'
 
@@ -11,7 +11,7 @@ interface HomePageProps {
   onOpentab: (nickname: string) => void
 }
 
-const pageLinks = IE_PAGES.filter((page) => page.nickname !== DEFAULT_ROUTE)
+const pageLinks = IE_TOP_PAGES.filter((page) => page.nickname !== DEFAULT_ROUTE)
 
 export function HomePage({ onNavigate, onOpentab }: HomePageProps) {
   return (

--- a/src/components/screens/desktop/StartMenu/StartMenu.tsx
+++ b/src/components/screens/desktop/StartMenu/StartMenu.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { isWindowDisabled } from '../disabledWindows'
+import { openWindowIfEnabled } from '../openWindowIfEnabled'
 import styles from './StartMenu.module.css'
 import { StartMenuItem } from './StartMenuItem'
 import {
@@ -16,8 +18,7 @@ import { Button } from '@/components/windows7/Button/index'
 import { signOut } from '@/lib/auth'
 import { DEFAULT_USER_ICON } from '@/lib/userIcons'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
-import { clearSession, selectAvatar } from '@/store/slices/sessionSlice'
-import { openWindow } from '@/store/slices/windowSlice'
+import { clearSession, selectAvatar, selectIsAdmin } from '@/store/slices/sessionSlice'
 
 /** Aero glass Start Menu panel. Controlled by parent via isOpen/onClose —
  *  the Taskbar (Task 14) owns the toggle state. Search filters the left
@@ -29,9 +30,23 @@ export interface StartMenuProps {
   avatarSrc?: string // Optional override (stories); defaults to the session avatar
 }
 
+/** A shortcut is dropped when its window is turned off site-wide, or (for guests)
+ *  when it is flagged hideForGuest. Non-window actions carry no key to disable. */
+function isShortcutDisabled(s: StartMenuShortcut, isAdmin: boolean): boolean {
+  return (
+    (isAdmin && Boolean(s.hideForAdmin)) ||
+    (!isAdmin && Boolean(s.hideForGuest)) ||
+    (s.action.type === 'openWindow' && isWindowDisabled(s.action.windowKey, isAdmin))
+  )
+}
+
 export function StartMenu({ isOpen, onClose, avatarSrc }: StartMenuProps) {
   const dispatch = useAppDispatch()
   const sessionAvatar = useAppSelector(selectAvatar)
+  // Shortcuts flagged hideForGuest are dropped entirely for guest sessions —
+  // guests cannot see or open them. The menu mounts on click, well after the
+  // session rehydrates, so reading the store role here cannot flash.
+  const isAdmin = useAppSelector(selectIsAdmin)
   const router = useRouter()
   const panelRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
@@ -43,13 +58,22 @@ export function StartMenu({ isOpen, onClose, avatarSrc }: StartMenuProps) {
     onClose()
   }, [onClose])
 
+  const visibleLeft = useMemo(
+    () => LEFT_COLUMN_SHORTCUTS.filter((s) => !isShortcutDisabled(s, isAdmin)),
+    [isAdmin]
+  )
+  const visibleRight = useMemo(
+    () => RIGHT_COLUMN_SHORTCUTS.filter((s) => !isShortcutDisabled(s, isAdmin)),
+    [isAdmin]
+  )
+
   const filteredLeft = useMemo(() => {
     if (!searchQuery.trim()) {
-      return LEFT_COLUMN_SHORTCUTS
+      return visibleLeft
     }
     const q = searchQuery.toLowerCase()
-    return LEFT_COLUMN_SHORTCUTS.filter((s) => s.label.toLowerCase().includes(q))
-  }, [searchQuery])
+    return visibleLeft.filter((s) => s.label.toLowerCase().includes(q))
+  }, [searchQuery, visibleLeft])
 
   useEffect(() => {
     if (!isOpen) {
@@ -119,7 +143,14 @@ export function StartMenu({ isOpen, onClose, avatarSrc }: StartMenuProps) {
   async function handleAction(action: StartMenuShortcut['action']) {
     handleClose()
     if (action.type === 'openWindow') {
-      dispatch(openWindow({ kind: action.kind, title: action.title }))
+      dispatch(
+        openWindowIfEnabled({
+          kind: action.kind,
+          title: action.title,
+          windowKey: action.windowKey,
+          size: action.size,
+        })
+      )
     } else if (action.type === 'openLink') {
       // External destinations go straight to a new tab — no IE window.
       window.open(action.url, '_blank', 'noopener')
@@ -176,7 +207,7 @@ export function StartMenu({ isOpen, onClose, avatarSrc }: StartMenuProps) {
             </div>
 
             <ul className={styles.shortcutList}>
-              {RIGHT_COLUMN_SHORTCUTS.map((shortcut) => (
+              {visibleRight.map((shortcut) => (
                 <StartMenuItem
                   key={shortcut.id}
                   {...(shortcut.iconSrc ? { iconSrc: shortcut.iconSrc } : {})}

--- a/src/components/screens/desktop/StartMenu/StartMenuItem.tsx
+++ b/src/components/screens/desktop/StartMenu/StartMenuItem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import styles from './StartMenuItem.module.css'
+import { withBasePath } from '@/lib/assetPaths'
 
 /** Single shortcut row used in both Start Menu columns.
  *  Follows WAI-ARIA menuitem pattern: focus is managed by the parent
@@ -30,7 +31,7 @@ export function StartMenuItem({ label, onClick, iconSrc = '' }: StartMenuItemPro
         // eslint-disable-next-line @next/next/no-img-element
         <img
           className={styles.itemIcon}
-          src={iconSrc}
+          src={withBasePath(iconSrc)}
           alt="" // Decorative — accessible name comes from the menuitem's label text
           width={24}
           height={24}

--- a/src/components/screens/desktop/StartMenu/startMenuItems.ts
+++ b/src/components/screens/desktop/StartMenu/startMenuItems.ts
@@ -1,3 +1,4 @@
+import { WINDOW_KEYS, type WindowKey } from '../windowKeys'
 import { assetPaths } from '@/lib/assetPaths'
 import type { WindowKind } from '@/store/slices/windowSlice'
 
@@ -10,8 +11,18 @@ export interface StartMenuShortcut {
   id: string
   label: string
   iconSrc?: string
+  hideForAdmin?: boolean
+  hideForGuest?: boolean
   action:
-    | { type: 'openWindow'; kind: WindowKind; title: string }
+    | {
+        type: 'openWindow'
+        kind: WindowKind
+        title: string
+        /** Stable id used for the disabled-window switch and the openWindow gate. */
+        windowKey: WindowKey
+        /** Optional initial window geometry; omitted = windowSlice default. */
+        size?: { width: number; height: number }
+      }
     | { type: 'openLink'; url: string }
     | { type: 'signOut' }
 }
@@ -32,13 +43,34 @@ export const LEFT_COLUMN_SHORTCUTS: StartMenuShortcut[] = [
     id: 'sm-ie',
     label: 'Internet Explorer',
     iconSrc: assetPaths.desktopIcons.internetExplorer,
-    action: { type: 'openWindow', kind: 'internet-explorer', title: 'Internet Explorer' },
+    action: {
+      type: 'openWindow',
+      kind: 'internet-explorer',
+      title: 'Internet Explorer',
+      windowKey: WINDOW_KEYS.internetExplorer,
+    },
+  },
+  {
+    id: 'sm-welcome',
+    label: 'Welcome',
+    iconSrc: FOLDER_ICON,
+    action: {
+      type: 'openWindow',
+      kind: 'internet-explorer',
+      title: 'Welcome',
+      windowKey: WINDOW_KEYS.welcome,
+    },
   },
   {
     id: 'sm-getting-started',
     label: 'Getting Started',
     iconSrc: FOLDER_ICON,
-    action: { type: 'openWindow', kind: 'internet-explorer', title: 'Getting Started' },
+    action: {
+      type: 'openWindow',
+      kind: 'internet-explorer',
+      title: 'Getting Started',
+      windowKey: WINDOW_KEYS.gettingStarted,
+    },
   },
 ]
 

--- a/src/components/screens/desktop/Taskbar/TaskbarIcon.module.css
+++ b/src/components/screens/desktop/Taskbar/TaskbarIcon.module.css
@@ -3,7 +3,6 @@
   height: 100%;
   display: flex;
   align-items: center;
-  padding: 0 var(--space-1);
 }
 
 /* Raise a hovered/focused group so its popup floats above adjacent items. */

--- a/src/components/screens/desktop/Taskbar/TaskbarIcon.tsx
+++ b/src/components/screens/desktop/Taskbar/TaskbarIcon.tsx
@@ -2,6 +2,7 @@
 
 import { taskbarAppMeta } from './taskbarApps'
 import styles from './TaskbarIcon.module.css'
+import { withBasePath } from '@/lib/assetPaths'
 import { useAppDispatch, useAppSelector } from '@/store/hooks'
 import {
   closeWindow,
@@ -65,7 +66,14 @@ export function TaskbarIcon({ kind, windows }: TaskbarIconProps) {
         type="button"
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={icon} alt="" width={24} height={24} draggable={false} />
+        <img
+          className={styles.icon}
+          src={withBasePath(icon)}
+          alt=""
+          width={24}
+          height={24}
+          draggable={false}
+        />
       </button>
 
       <ul className={styles.popup}>
@@ -80,7 +88,7 @@ export function TaskbarIcon({ kind, windows }: TaskbarIconProps) {
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 className={styles.popupIcon}
-                src={icon}
+                src={withBasePath(icon)}
                 alt=""
                 width={20}
                 height={20}

--- a/src/components/screens/desktop/WindowWrapper/WindowWrapper.module.css
+++ b/src/components/screens/desktop/WindowWrapper/WindowWrapper.module.css
@@ -74,6 +74,14 @@
   user-select: none;
 }
 
+/* During a drag/resize gesture, embedded documents (game canvases, PDF
+   viewers) must not hit-test or hover-track the pointer sweeping across
+   them — the gesture belongs to the captured handle, and cross-document hit
+   testing is wasted work per pointermove. */
+.dragging iframe {
+  pointer-events: none;
+}
+
 .maximized :global(.window) {
   border-radius: 0;
   box-shadow: none;

--- a/src/components/screens/desktop/desktopIcons.ts
+++ b/src/components/screens/desktop/desktopIcons.ts
@@ -1,3 +1,4 @@
+import { WINDOW_KEYS, type WindowKey } from './windowKeys'
 import { assetPaths } from '@/lib/assetPaths'
 import type { WindowKind } from '@/store/slices/windowSlice'
 
@@ -7,6 +8,14 @@ export interface DesktopIconDefinition {
   iconSrc: string
   windowKind: WindowKind
   windowTitle: string
+  /** Stable id used for the disabled-window switch and the openWindow gate. */
+  windowKey: WindowKey
+  /** Optional initial window geometry; omitted = windowSlice default. */
+  windowSize?: { width: number; height: number }
+  /** Hide this icon on the admin desktop (guest sessions still show it). */
+  hideForAdmin?: boolean
+  /** Hide this icon from guest sessions (guests cannot see or open it). */
+  hideForGuest?: boolean
 }
 
 const FOLDER_ICON = assetPaths.desktopIcons.folderWithDocuments
@@ -18,6 +27,7 @@ export const DESKTOP_ICONS: DesktopIconDefinition[] = [
     iconSrc: assetPaths.desktopIcons.internetExplorer,
     windowKind: 'internet-explorer',
     windowTitle: 'Internet Explorer',
+    windowKey: WINDOW_KEYS.internetExplorer,
   },
   {
     id: 'icon-welcome',
@@ -25,6 +35,7 @@ export const DESKTOP_ICONS: DesktopIconDefinition[] = [
     iconSrc: FOLDER_ICON,
     windowKind: 'welcome',
     windowTitle: 'Welcome',
+    windowKey: WINDOW_KEYS.welcome,
   },
   {
     id: 'icon-getting-started',
@@ -33,5 +44,6 @@ export const DESKTOP_ICONS: DesktopIconDefinition[] = [
     windowKind: 'internet-explorer',
     // Matches an IE page title, so the window opens directly on that page.
     windowTitle: 'Getting Started',
+    windowKey: WINDOW_KEYS.gettingStarted,
   },
 ]

--- a/src/components/screens/desktop/disabledWindows.ts
+++ b/src/components/screens/desktop/disabledWindows.ts
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for windows that are turned off site-wide.
+ *
+ * A window whose key is listed here is removed from EVERY entry point — the
+ * desktop icon grid, the Start Menu, and the openWindow gate alike — so the
+ * user can neither see nor open it in any location. This is the one switch to
+ * flip: add a window's key to turn it off everywhere; remove it to restore full
+ * access. Keys (not display titles) are matched, so renaming a window's title
+ * never silently re-enables it.
+ */
+import type { WindowKey } from './windowKeys'
+
+// To disable a window, add its key from WINDOW_KEYS (windowKeys.ts) below, e.g.
+// WINDOW_KEYS.welcome — import { WINDOW_KEYS } when you do.
+export const DISABLED_WINDOWS_GUEST: ReadonlySet<WindowKey> = new Set<WindowKey>([])
+
+export const DISABLED_WINDOWS_ADMIN: ReadonlySet<WindowKey> = new Set<WindowKey>([])
+
+/** True when the window with this key is turned off everywhere. */
+export function isWindowDisabled(key: WindowKey, isAdmin?: boolean): boolean {
+  return isAdmin ? DISABLED_WINDOWS_ADMIN.has(key) : DISABLED_WINDOWS_GUEST.has(key)
+}

--- a/src/components/screens/desktop/openWindowIfEnabled.ts
+++ b/src/components/screens/desktop/openWindowIfEnabled.ts
@@ -1,0 +1,25 @@
+import { isWindowDisabled } from './disabledWindows'
+import type { WindowKey } from './windowKeys'
+import type { AppDispatch, RootState } from '@/store'
+import { selectIsAdmin } from '@/store/slices/sessionSlice'
+import { openWindow, type WindowKind } from '@/store/slices/windowSlice'
+
+/**
+ * The single gate for opening a window. Refuses windows turned off site-wide
+ * (see disabledWindows) before dispatching openWindow, so no launcher — desktop
+ * icon or Start Menu — can open a disabled window. Every launch path dispatches
+ * this thunk instead of the raw openWindow action.
+ */
+export const openWindowIfEnabled =
+  (params: {
+    kind: WindowKind
+    title: string
+    windowKey: WindowKey
+    size?: { width: number; height: number }
+  }) =>
+  (dispatch: AppDispatch, getState: () => RootState): void => {
+    if (isWindowDisabled(params.windowKey, selectIsAdmin(getState()))) {
+      return
+    }
+    dispatch(openWindow({ kind: params.kind, title: params.title, size: params.size }))
+  }

--- a/src/components/screens/desktop/windowKeys.ts
+++ b/src/components/screens/desktop/windowKeys.ts
@@ -1,0 +1,13 @@
+/**
+ * Stable identifiers for each launchable window. A window key is decoupled from
+ * the display title (which also drives IE routing), so the disabled-window
+ * switch and the openWindow gate key off an id that never changes when copy
+ * does. Add a key here when you add a launchable window.
+ */
+export const WINDOW_KEYS = {
+  internetExplorer: 'window-internet-explorer',
+  welcome: 'window-welcome',
+  gettingStarted: 'window-getting-started',
+} as const
+
+export type WindowKey = (typeof WINDOW_KEYS)[keyof typeof WINDOW_KEYS]

--- a/src/hooks/useDesktopPersistence.ts
+++ b/src/hooks/useDesktopPersistence.ts
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+
+import {
+  readIconPositions,
+  readWindowSizes,
+  writeIconPositions,
+  writeWindowSizes,
+} from '@/lib/desktopPersistence'
+import { useAppStore } from '@/store/hooks'
+import { hydrateIconPositions, selectIconsById } from '@/store/slices/desktopSlice'
+import { hydrateWindowSizes, selectWindowSizes } from '@/store/slices/windowSlice'
+
+/**
+ * Desktop-layout persistence. On desktop boot, hydrates the per-kind window
+ * sizes and the icon grid positions from their sessionStorage markers, then
+ * subscribes to the store and mirrors every later change back. Change
+ * detection is by reference identity — Immer replaces exactly the objects a
+ * reducer touched, so a stale reference means nothing to write.
+ */
+export function useDesktopPersistence(): void {
+  const store = useAppStore()
+
+  useEffect(() => {
+    const savedSizes = readWindowSizes()
+    if (savedSizes) {
+      store.dispatch(hydrateWindowSizes(savedSizes))
+    }
+    const savedPositions = readIconPositions()
+    if (savedPositions) {
+      store.dispatch(hydrateIconPositions(savedPositions))
+    }
+
+    let lastSizes = selectWindowSizes(store.getState())
+    let lastIcons = selectIconsById(store.getState())
+    return store.subscribe(() => {
+      const sizes = selectWindowSizes(store.getState())
+      if (sizes !== lastSizes) {
+        lastSizes = sizes
+        writeWindowSizes(sizes)
+      }
+      const icons = selectIconsById(store.getState())
+      if (icons !== lastIcons) {
+        lastIcons = icons
+        writeIconPositions(
+          Object.fromEntries(Object.values(icons).map((icon) => [icon.id, icon.position]))
+        )
+      }
+    })
+  }, [store])
+}

--- a/src/hooks/useDesktopPersistence.ts
+++ b/src/hooks/useDesktopPersistence.ts
@@ -2,20 +2,28 @@ import { useEffect } from 'react'
 
 import {
   readIconPositions,
+  readWindowPositions,
   readWindowSizes,
   writeIconPositions,
+  writeWindowPositions,
   writeWindowSizes,
 } from '@/lib/desktopPersistence'
 import { useAppStore } from '@/store/hooks'
 import { hydrateIconPositions, selectIconsById } from '@/store/slices/desktopSlice'
-import { hydrateWindowSizes, selectWindowSizes } from '@/store/slices/windowSlice'
+import {
+  hydrateWindowPositions,
+  hydrateWindowSizes,
+  selectWindowPositions,
+  selectWindowSizes,
+} from '@/store/slices/windowSlice'
 
 /**
  * Desktop-layout persistence. On desktop boot, hydrates the per-kind window
- * sizes and the icon grid positions from their sessionStorage markers, then
- * subscribes to the store and mirrors every later change back. Change
- * detection is by reference identity — Immer replaces exactly the objects a
- * reducer touched, so a stale reference means nothing to write.
+ * sizes, the per-kind window positions, and the icon grid positions from their
+ * sessionStorage markers, then subscribes to the store and mirrors every later
+ * change back. Change detection is by reference identity — Immer replaces
+ * exactly the objects a reducer touched, so a stale reference means nothing to
+ * write.
  */
 export function useDesktopPersistence(): void {
   const store = useAppStore()
@@ -25,18 +33,28 @@ export function useDesktopPersistence(): void {
     if (savedSizes) {
       store.dispatch(hydrateWindowSizes(savedSizes))
     }
+    const savedWindowPositions = readWindowPositions()
+    if (savedWindowPositions) {
+      store.dispatch(hydrateWindowPositions(savedWindowPositions))
+    }
     const savedPositions = readIconPositions()
     if (savedPositions) {
       store.dispatch(hydrateIconPositions(savedPositions))
     }
 
     let lastSizes = selectWindowSizes(store.getState())
+    let lastWindowPositions = selectWindowPositions(store.getState())
     let lastIcons = selectIconsById(store.getState())
     return store.subscribe(() => {
       const sizes = selectWindowSizes(store.getState())
       if (sizes !== lastSizes) {
         lastSizes = sizes
         writeWindowSizes(sizes)
+      }
+      const windowPositions = selectWindowPositions(store.getState())
+      if (windowPositions !== lastWindowPositions) {
+        lastWindowPositions = windowPositions
+        writeWindowPositions(windowPositions)
       }
       const icons = selectIconsById(store.getState())
       if (icons !== lastIcons) {

--- a/src/lib/assetPaths.ts
+++ b/src/lib/assetPaths.ts
@@ -73,3 +73,14 @@ export function cssAssetVars(): Record<string, string> {
     '--tb-orb-img': `url('${BASE_PATH}${assetPaths.taskbar.startOrb}')`,
   }
 }
+
+/**
+ * Prefixes a root-absolute `public/` path with the configured BASE_PATH.
+ * Required for plain <img>/<iframe> srcs, anchor hrefs, and fetch() URLs —
+ * unlike router navigations and next/image, raw element URLs are not
+ * basePath-aware and would resolve against the domain root under a subpath
+ * mount.
+ */
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`
+}

--- a/src/lib/desktopPersistence.ts
+++ b/src/lib/desktopPersistence.ts
@@ -6,9 +6,10 @@ import type { WindowKind } from '@/store/slices/windowSlice'
 /** Single owner of the desktop-layout persistence markers:
  *
  *    1. win7.windowSizes — last committed window size, keyed by window kind.
- *    2. win7.iconPositions — desktop-icon grid cell, keyed by icon id.
+ *    2. win7.windowPositions — last committed window position, keyed by window kind.
+ *    3. win7.iconPositions — desktop-icon grid cell, keyed by icon id.
  *
- *  Both live in sessionStorage (survive reloads within the tab, end when the
+ *  All live in sessionStorage (survive reloads within the tab, end when the
  *  tab closes) and flow through Redux: useDesktopPersistence hydrates them
  *  into the slices at desktop boot and writes changes back. A malformed or
  *  tampered marker is evicted so the next read is clean — same contract as
@@ -17,11 +18,17 @@ import type { WindowKind } from '@/store/slices/windowSlice'
 // Namespaced to prevent collisions with other sessionStorage consumers
 // (browser extensions, embedded widgets).
 const WINDOW_SIZES_KEY = 'win7.windowSizes'
+const WINDOW_POSITIONS_KEY = 'win7.windowPositions'
 const ICON_POSITIONS_KEY = 'win7.iconPositions'
 
 const WindowSizesSchema = z.record(
   z.string(),
   z.object({ width: z.number(), height: z.number() })
+)
+
+const WindowPositionsSchema = z.record(
+  z.string(),
+  z.object({ x: z.number(), y: z.number() })
 )
 
 const IconPositionsSchema = z.record(
@@ -30,6 +37,7 @@ const IconPositionsSchema = z.record(
 )
 
 export type PersistedWindowSizes = Partial<Record<WindowKind, { width: number; height: number }>>
+export type PersistedWindowPositions = Partial<Record<WindowKind, { x: number; y: number }>>
 export type PersistedIconPositions = Record<string, GridCell>
 
 /** Reads and validates the persisted per-kind window sizes, if any. */
@@ -39,6 +47,15 @@ export function readWindowSizes(): PersistedWindowSizes | null {
 
 export function writeWindowSizes(sizes: PersistedWindowSizes): void {
   writeMarker(WINDOW_SIZES_KEY, sizes)
+}
+
+/** Reads and validates the persisted per-kind window positions, if any. */
+export function readWindowPositions(): PersistedWindowPositions | null {
+  return readMarker(WINDOW_POSITIONS_KEY, WindowPositionsSchema)
+}
+
+export function writeWindowPositions(positions: PersistedWindowPositions): void {
+  writeMarker(WINDOW_POSITIONS_KEY, positions)
 }
 
 /** Reads and validates the persisted icon positions, if any. */

--- a/src/lib/desktopPersistence.ts
+++ b/src/lib/desktopPersistence.ts
@@ -1,0 +1,84 @@
+import z from 'zod'
+
+import type { GridCell } from '@/store/slices/desktopSlice'
+import type { WindowKind } from '@/store/slices/windowSlice'
+
+/** Single owner of the desktop-layout persistence markers:
+ *
+ *    1. win7.windowSizes — last committed window size, keyed by window kind.
+ *    2. win7.iconPositions — desktop-icon grid cell, keyed by icon id.
+ *
+ *  Both live in sessionStorage (survive reloads within the tab, end when the
+ *  tab closes) and flow through Redux: useDesktopPersistence hydrates them
+ *  into the slices at desktop boot and writes changes back. A malformed or
+ *  tampered marker is evicted so the next read is clean — same contract as
+ *  guestSession/adminSession. */
+
+// Namespaced to prevent collisions with other sessionStorage consumers
+// (browser extensions, embedded widgets).
+const WINDOW_SIZES_KEY = 'win7.windowSizes'
+const ICON_POSITIONS_KEY = 'win7.iconPositions'
+
+const WindowSizesSchema = z.record(
+  z.string(),
+  z.object({ width: z.number(), height: z.number() })
+)
+
+const IconPositionsSchema = z.record(
+  z.string(),
+  z.object({ column: z.number(), row: z.number() })
+)
+
+export type PersistedWindowSizes = Partial<Record<WindowKind, { width: number; height: number }>>
+export type PersistedIconPositions = Record<string, GridCell>
+
+/** Reads and validates the persisted per-kind window sizes, if any. */
+export function readWindowSizes(): PersistedWindowSizes | null {
+  return readMarker(WINDOW_SIZES_KEY, WindowSizesSchema)
+}
+
+export function writeWindowSizes(sizes: PersistedWindowSizes): void {
+  writeMarker(WINDOW_SIZES_KEY, sizes)
+}
+
+/** Reads and validates the persisted icon positions, if any. */
+export function readIconPositions(): PersistedIconPositions | null {
+  return readMarker(ICON_POSITIONS_KEY, IconPositionsSchema)
+}
+
+export function writeIconPositions(positions: PersistedIconPositions): void {
+  writeMarker(ICON_POSITIONS_KEY, positions)
+}
+
+function readMarker<Schema extends z.ZodType>(
+  key: string,
+  schema: Schema
+): z.infer<Schema> | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  const raw = window.sessionStorage.getItem(key)
+  if (!raw) {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    window.sessionStorage.removeItem(key)
+    return null
+  }
+  const validated = schema.safeParse(parsed)
+  if (!validated.success) {
+    window.sessionStorage.removeItem(key)
+    return null
+  }
+  return validated.data
+}
+
+function writeMarker(key: string, value: unknown): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  window.sessionStorage.setItem(key, JSON.stringify(value))
+}

--- a/src/store/slices/desktopSlice.ts
+++ b/src/store/slices/desktopSlice.ts
@@ -27,6 +27,10 @@ export interface DesktopState {
   iconIds: string[] // stable registration order for rendering
   selectedIconId: string | null // single-selection model
   persistPositions: boolean // role-derived: is the current layout durable?
+  // Positions hydrated from sessionStorage (useDesktopPersistence). Kept as a
+  // standalone map — not merged into iconsById — because hydration and icon
+  // registration race at boot: whichever runs second consults the other.
+  savedPositions: Record<string, GridCell>
 }
 
 // ─── Initial State ──────────────────────────────────────────────────────────
@@ -39,6 +43,7 @@ const initialState: DesktopState = {
   iconIds: [],
   selectedIconId: null,
   persistPositions: false,
+  savedPositions: {},
 }
 
 function resetDesktopIcons(state: DesktopState): void {
@@ -46,6 +51,22 @@ function resetDesktopIcons(state: DesktopState): void {
     const desktopIcon = state.iconsById[iconId]
     desktopIcon.position = { ...desktopIcon.defaultPosition }
   })
+}
+
+// Scan down rows from `desired` for the first cell no already-registered icon
+// occupies (compared via `cellOf`, so the live layout and the reset layout are
+// each kept collision-free). Column-major single-column growth mirrors the seed
+// layout; the finite icon count guarantees a free row is found and terminates.
+function firstFreeCell(
+  desired: GridCell,
+  icons: DesktopIcon[],
+  cellOf: (icon: DesktopIcon) => GridCell
+): GridCell {
+  let { column, row } = desired
+  while (icons.some((icon) => cellOf(icon).column === column && cellOf(icon).row === row)) {
+    row += 1
+  }
+  return { column, row }
 }
 
 const desktopSlice = createSlice({
@@ -57,7 +78,30 @@ const desktopSlice = createSlice({
       if (state.iconsById[action.payload.id]) {
         return
       }
-      state.iconsById[action.payload.id] = action.payload
+      // Occupancy-aware seeding: an icon never lands on a cell another icon
+      // already holds. The seed (or a hydrated position) is only a starting
+      // hint — if it is taken we slide to the next free cell. Resolved
+      // independently for the live position and the reset default so neither
+      // layout can stack, e.g. when a same-tab role switch registers a new icon
+      // onto a row a prior role already placed. A hydrated position still wins
+      // over the seed as the desired starting cell.
+      const registered = state.iconIds.map((id) => state.iconsById[id])
+      const defaultPosition = firstFreeCell(
+        action.payload.defaultPosition,
+        registered,
+        (icon) => icon.defaultPosition
+      )
+      const saved = state.savedPositions[action.payload.id]
+      const position = firstFreeCell(
+        saved ?? action.payload.position,
+        registered,
+        (icon) => icon.position
+      )
+      state.iconsById[action.payload.id] = {
+        id: action.payload.id,
+        position,
+        defaultPosition,
+      }
       state.iconIds.push(action.payload.id)
     },
 
@@ -89,6 +133,20 @@ const desktopSlice = createSlice({
       resetDesktopIcons(state)
       state.selectedIconId = null
     },
+
+    // ── hydrateIconPositions ──────────────────────────────────────────────
+    // Payload: the persisted id → grid-cell map. Dispatched once at desktop
+    // boot (useDesktopPersistence). Applies to icons already registered and
+    // is kept in savedPositions for icons that register afterwards.
+    hydrateIconPositions(state, action: PayloadAction<Record<string, GridCell>>) {
+      state.savedPositions = action.payload
+      Object.entries(action.payload).forEach(([id, position]) => {
+        const icon = state.iconsById[id]
+        if (icon) {
+          icon.position = { ...position }
+        }
+      })
+    },
   },
 
   // extraReducers added in Step 4.
@@ -119,6 +177,12 @@ const desktopSlice = createSlice({
 // Category 1 — field access. No memoization.
 export const selectSelectedIconId = (state: RootState): string | null => {
   return state.desktop.selectedIconId
+}
+
+// Category 2 — returns the stored reference; consumed by useDesktopPersistence
+// to change-detect (by identity) and write positions through to sessionStorage.
+export const selectIconsById = (state: RootState): Record<string, DesktopIcon> => {
+  return state.desktop.iconsById
 }
 
 // Category 2 — O(1) lookup, higher-order (parameterized by id), mirrors selectWindowById.
@@ -153,6 +217,7 @@ export const {
   setSelectedIcon,
   clearSelection,
   resetGuestPositions,
+  hydrateIconPositions,
 } = desktopSlice.actions
 
 export default desktopSlice.reducer

--- a/src/store/slices/windowSlice.ts
+++ b/src/store/slices/windowSlice.ts
@@ -50,7 +50,8 @@ export interface WindowState {
   // back on change by useDesktopPersistence.
   sizeByKind: Partial<Record<WindowKind, { width: number; height: number }>>
   // Last committed position per window kind — a reopened window of that kind
-  // restores it. Slice memory only (not persisted across reloads).
+  // restores it. Hydrated from sessionStorage at desktop boot and written
+  // back on change by useDesktopPersistence.
   positionByKind: Partial<Record<WindowKind, { x: number; y: number }>>
 }
 
@@ -289,6 +290,16 @@ const windowSlice = createSlice({
     ) {
       state.sizeByKind = action.payload
     },
+
+    // ── hydrateWindowPositions ────────────────────────────────────────────
+    // Payload: the persisted per-kind position map. Dispatched once at desktop
+    // boot (useDesktopPersistence) before any window opens.
+    hydrateWindowPositions(
+      state,
+      action: PayloadAction<Partial<Record<WindowKind, { x: number; y: number }>>>
+    ) {
+      state.positionByKind = action.payload
+    },
   },
 })
 
@@ -305,6 +316,14 @@ export const selectWindowSizes = (
   state: RootState
 ): Partial<Record<WindowKind, { width: number; height: number }>> => {
   return state.window.sizeByKind
+}
+
+// Category 2 — returns the stored reference; consumed by useDesktopPersistence
+// to change-detect (by identity) and write the map through to sessionStorage.
+export const selectWindowPositions = (
+  state: RootState
+): Partial<Record<WindowKind, { x: number; y: number }>> => {
+  return state.window.positionByKind
 }
 
 // Category 2 — O(1) lookup. Returns a stored reference; no new allocation.
@@ -364,5 +383,6 @@ export const {
   moveWindow,
   resizeWindow,
   hydrateWindowSizes,
+  hydrateWindowPositions,
 } = windowSlice.actions
 export default windowSlice.reducer

--- a/src/store/slices/windowSlice.ts
+++ b/src/store/slices/windowSlice.ts
@@ -4,7 +4,7 @@ import type { RootState } from '@/store'
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
 
-const DEFAULT_WINDOW_SIZE = { width: 640, height: 440 }
+const DEFAULT_WINDOW_SIZE = { width: 880, height: 640 }
 const DEFAULT_WINDOW_POSITION = { x: 80, y: 80 }
 // Canonical minimum — the --mw-min-* tokens in globals.css are kept in sync
 // by src/lib/designTokens.test.ts.
@@ -45,6 +45,13 @@ export interface WindowState {
   ids: string[]
   zCounter: number
   nextIdSeed: number
+  // Last committed size per window kind — a reopened window of that kind
+  // restores it. Hydrated from sessionStorage at desktop boot and written
+  // back on change by useDesktopPersistence.
+  sizeByKind: Partial<Record<WindowKind, { width: number; height: number }>>
+  // Last committed position per window kind — a reopened window of that kind
+  // restores it. Slice memory only (not persisted across reloads).
+  positionByKind: Partial<Record<WindowKind, { x: number; y: number }>>
 }
 
 // ─── Initial State ──────────────────────────────────────────────────────────
@@ -56,6 +63,8 @@ const initialState: WindowState = {
   ids: [],
   zCounter: 0,
   nextIdSeed: 0,
+  sizeByKind: {},
+  positionByKind: {},
 }
 
 const windowSlice = createSlice({
@@ -79,10 +88,21 @@ const windowSlice = createSlice({
       //   2. Bump state.zCounter; the new window's zIndex = state.zCounter
       state.zCounter++
       const zIndex = state.zCounter
-      //   3. Default position to { x: 80, y: 80 } if not provided.
-      const position = action.payload.position ?? DEFAULT_WINDOW_POSITION
-      //   4. Default size to { width: 640, height: 440 } if not provided.
-      const size = action.payload.size ?? DEFAULT_WINDOW_SIZE
+      //   3. Position precedence mirrors size: last committed position for
+      //      this kind (restores the user's placement on reopen) → caller-
+      //      provided position → the module default. Copied so byId never
+      //      aliases the positionByKind entry.
+      const position = {
+        ...(state.positionByKind[action.payload.kind] ??
+          action.payload.position ??
+          DEFAULT_WINDOW_POSITION),
+      }
+      //   4. Size precedence: last committed size for this kind (restores the
+      //      user's sizing on reopen) → caller-provided initial size → the
+      //      module default. Copied so byId never aliases the sizeByKind entry.
+      const size = {
+        ...(state.sizeByKind[action.payload.kind] ?? action.payload.size ?? DEFAULT_WINDOW_SIZE),
+      }
       //   5. isMinimized and isMaximized start false; prevGeometry starts null.
       const isMinimized = false
       const isMaximized = false
@@ -232,6 +252,9 @@ const windowSlice = createSlice({
       //      DO NOT clamp here. Boundary clamping is the responsibility of the
       //      component drag handler (Task 11) which has access to the viewport.
       window.position = { x: action.payload.x, y: action.payload.y }
+      //   4. Remember the committed position for this kind so the next window
+      //      of the same kind reopens at it.
+      state.positionByKind[window.kind] = { ...window.position }
     },
 
     // ── resizeWindow ──────────────────────────────────────────────────────
@@ -252,6 +275,19 @@ const windowSlice = createSlice({
         width: Math.max(action.payload.width, MIN_WINDOW_SIZE.width),
         height: Math.max(action.payload.height, MIN_WINDOW_SIZE.height),
       }
+      //   4. Remember the committed size for this kind so the next window of
+      //      the same kind (and reloads, via persistence) reopens at it.
+      state.sizeByKind[window.kind] = { ...window.size }
+    },
+
+    // ── hydrateWindowSizes ────────────────────────────────────────────────
+    // Payload: the persisted per-kind size map. Dispatched once at desktop
+    // boot (useDesktopPersistence) before any window opens.
+    hydrateWindowSizes(
+      state,
+      action: PayloadAction<Partial<Record<WindowKind, { width: number; height: number }>>>
+    ) {
+      state.sizeByKind = action.payload
     },
   },
 })
@@ -261,6 +297,14 @@ const windowSlice = createSlice({
 // Category 1 — primitive field access. No memoization needed.
 export const selectZCounter = (state: RootState): number => {
   return state.window.zCounter
+}
+
+// Category 2 — returns the stored reference; consumed by useDesktopPersistence
+// to change-detect (by identity) and write the map through to sessionStorage.
+export const selectWindowSizes = (
+  state: RootState
+): Partial<Record<WindowKind, { width: number; height: number }>> => {
+  return state.window.sizeByKind
 }
 
 // Category 2 — O(1) lookup. Returns a stored reference; no new allocation.
@@ -319,5 +363,6 @@ export const {
   toggleMaximize,
   moveWindow,
   resizeWindow,
+  hydrateWindowSizes,
 } = windowSlice.actions
 export default windowSlice.reducer


### PR DESCRIPTION
# Version 1.2 — Desktop layout persistence, per-role windows, IE7 chrome

This release makes the desktop **remember how you left it**, adds a **site-wide
window enable/disable system** with per-role visibility, gives Internet Explorer
an authentic **IE7 tab strip and status bar**, and lifts the toolchain to a
**Node 22 baseline**.

## ✨ Features

### Desktop layout & window geometry now persist across reloads

The desktop remembers its layout within a browser tab (survives reloads, clears
when the tab closes).

- **New persistence layer** (`src/lib/desktopPersistence.ts`) — a single owner
  of three namespaced `sessionStorage` markers: `win7.windowSizes`,
  `win7.windowPositions`, and `win7.iconPositions`. Each marker is Zod-validated
  on read; a malformed or tampered value is evicted so the next read is clean
  (same contract as the guest/admin session markers).
- **New `useDesktopPersistence` hook** — hydrates the slices at desktop boot,
  then subscribes to the store and mirrors every later change back. Change
  detection is by reference identity (Immer replaces only the objects a reducer
  touched), so writes happen only when something actually moved or resized.
- **Per-kind window geometry** — `windowSlice` now tracks last-committed **size**
  and **position** per window *kind*. Reopening a window of that kind restores
  the user's sizing and placement. Precedence on open: last-committed geometry →
  caller-provided initial geometry → module default.
- **Larger default window** — the fallback window size moves from `640×440` to
  `880×640`.

### Site-wide window gating with per-role visibility

A new, single-switch system for turning windows on/off and hiding icons per
account role.

- **Stable window keys** (`windowKeys.ts`) — each launchable window has an id
  decoupled from its display title, so renaming window copy never silently
  changes gating behavior.
- **One off-switch** (`disabledWindows.ts`) — adding a window's key to
  `DISABLED_WINDOWS_GUEST` / `DISABLED_WINDOWS_ADMIN` removes it from **every**
  entry point at once: the desktop icon grid, the Start Menu, and the open gate.
- **A single open gate** (`openWindowIfEnabled` thunk) — every launch path
  (desktop icons *and* Start Menu) now dispatches through this gate instead of
  the raw `openWindow` action, so a disabled window cannot be opened from
  anywhere.
- **Per-role icon/shortcut hiding** — new `hideForAdmin` / `hideForGuest` flags
  on desktop-icon and Start-Menu registries. Icons flagged for the current role
  never register a grid cell (no flash, no phantom occupancy).
- **Unified role source** — the `/win7/desktop` deep link now derives the admin
  flag exactly the way `/win7` does, so guest (the complement of admin) is
  treated identically on both routes. A **Welcome** shortcut was added to the
  Start Menu's left column.

### Icon stacking fix

Desktop icon registration is now **occupancy-aware** (`firstFreeCell`): an icon
whose seed or hydrated cell is already taken slides to the next free row instead
of stacking on top. Resolved independently for the live layout and the
reset-default layout, which fixes overlap when a same-tab role switch registers
a new icon onto an occupied row.

## 🎨 UI / Style

### Internet Explorer — IE7 retro chrome

- **New single-tab strip** under the address bar with a Favorites-Center star,
  favicon, current-page title, and a new-tab stub (decorative, `aria-hidden`).
- **New status bar** along the window bottom:
  `Done · Internet | Protected Mode: Off · 100%`.
- **Address field** restyled from a sunken 2px inset (which read as IE6/XP) to a
  flat 1px hairline with square corners, matching IE7's glass-flush field.
- **Page-links bar** now sits on the IE7 chrome band with a bottom border, so it
  reads as the browser's Links bar rather than page content.
- **New CSS design tokens** for in-page content cards, the shared chrome band,
  tab treatment, and status bar.
- Toolbar action dividers thinned from 2px to 1px; taskbar icon padding
  tightened.

### Top-level IE pages only in navigation

New `IE_TOP_PAGES` filter — nested subpage nicknames (e.g. `about:projects/…`)
are excluded from the page-links row and the Home tiles, and are reachable from
their parent page instead.

## 🌐 Cross-browser & subpath robustness

- **`withBasePath()` helper** (`assetPaths.ts`) — prefixes raw `public/` paths
  with the configured `BASE_PATH`. Applied to plain `<img>` / `<iframe>` srcs
  across IE, Start Menu, and taskbar icons, which (unlike `next/image` and router
  navigations) are **not** basePath-aware and would otherwise break under a
  subpath mount.
- **Drag/resize gesture fix** — embedded documents (game canvases, PDF viewers)
  no longer hit-test the pointer mid-gesture
  (`.dragging iframe { pointer-events: none }`). The gesture stays with the
  captured handle, removing the need for the prior Firefox-specific opt-outs.

## 🔧 Tooling / Chore

- **Node 22 baseline** — added `engines.node >= 22`; bumped `@types/node` to
  match.
- **Documented a `dotenv-expand` gotcha** in `.env.example`: Next.js expands
  `.env` values, so a literal `$` in a secret (e.g. `ADMIN_PASSWORD`) must be
  escaped as `\$` (quotes don't protect it). Hosting-provider dashboards take the
  raw, unescaped value.

---

**Commits in this release:**

- `d099dc7` feat: persist desktop layout and per-kind window geometry
- `f698d8c` feat: fix icon stacking, unify guest source, gate window opens by key, drop Firefox opt-outs
- `4860a05` style: IE window and desktop chrome polish
- `1be6d76` feat: window positioning session persistence
- `ae831e2` chore: adopt Node 22 baseline; document dotenv-expand $ gotcha
